### PR TITLE
Recommendation: switch Webpack config settings to enable tree-shaking while retaining debugging for Kolmafia

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
     // Point "entry" to scripts you want to be CLI-eligible.
     "main-script-name": "./src/main.ts",
   },
-  mode: "development",
+  // Turns on tree-shaking and minification in the default Terser minifier
+  // https://webpack.js.org/plugins/terser-webpack-plugin/
+  mode: "production",
   devtool: false,
   output: {
     // Change the final string here to the name you want your script to use in mafia.
@@ -27,6 +29,14 @@ module.exports = {
         loader: "babel-loader",
       },
     ],
+  },
+  optimization: {
+    // Disable minification because it makes debugging really a pain in the ass, but we still want tree-shaking
+    minimize: false,
+  },
+  performance: {
+    // Disable the warning about assets exceeding the recommended size because this isn't a website script
+    hints: false,
   },
   plugins: [],
   externals: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
     ],
   },
   optimization: {
-    // Disable minification because it makes debugging really a pain in the ass, but we still want tree-shaking
+    // Disable compression because it makes debugging more difficult for KolMafia
     minimize: false,
   },
   performance: {


### PR DESCRIPTION
These changes to Webpack config should make tree-shaking work properly without destroying code formatting and symbol names since Rhino can't handle source maps (as far as I'm aware). By default it should help save some space for users, but more importantly it should reduce the quantity of lines changed when third-party libraries are updated/included with more unused functions in development mode.