### PR TITLE
Update webpack to resolve opensslErrorStack

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-libram": "^0.1.9",
     "prettier": "^2.3.2",
     "typescript": "^4.4.2",
-    "webpack": "^5.51.1",
+    "webpack": "^5.61.0",
     "webpack-cli": "^4.8.0"
   },
   "dependencies": {


### PR DESCRIPTION
```
opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
library: 'digital envelope routines',
reason: 'unsupported',
code: 'ERR_OSSL_EVP_UNSUPPORTED'
```

That error was thrown due to a no longer supported openSSL-algorithm in the previous webpack version

(First ever PR, yay)